### PR TITLE
explicitly wrapping each element of the list in a types.DynamicValue.…

### DIFF
--- a/provider/data_source_dirmap.go
+++ b/provider/data_source_dirmap.go
@@ -130,7 +130,7 @@ func convertToAttrValueSingle(ctx context.Context, v interface{}) (attr.Value, d
 			if diags.HasError() {
 				return nil, diags
 			}
-			elements[i] = elemVal
+			elements[i] = types.DynamicValue(elemVal)
 		}
 		return types.ListValueMust(types.DynamicType, elements), diags
 	case string:


### PR DESCRIPTION
… This will ensure all elements have the same

  DynamicType, which will resolve the crash when creating the list.