### PR TITLE
update dirmap function to allow filter option to be optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ go.work.sum
 
 # env file
 .env
+.envrc
 
 # Editor/IDE
 # .idea/

--- a/provider/function_dirmap.go
+++ b/provider/function_dirmap.go
@@ -46,18 +46,16 @@ func (f *dirmapFunction) Definition(_ context.Context, _ function.DefinitionRequ
 // Run executes the function.
 func (f *dirmapFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
 	var path string
-	var filterArgs []string
+	var filter string
 
 	// Read required path argument
 	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.Get(ctx, &path))
 
 	// Read optional variadic filter argument
-	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.GetVariadic(ctx, &filterArgs))
-
-	// Default filter to empty string if not provided
-	filter := ""
-	if len(filterArgs) > 0 {
-		filter = filterArgs[0]
+	// If not provided, Get will return an error which we can ignore
+	if err := req.Arguments.Get(ctx, &filter); err != nil {
+		// Filter not provided, use empty string as default
+		filter = ""
 	}
 
 	// Build the map (reuses your existing logic)

--- a/provider/function_dirmap.go
+++ b/provider/function_dirmap.go
@@ -34,10 +34,10 @@ func (f *dirmapFunction) Definition(_ context.Context, _ function.DefinitionRequ
 				Name:        "path",
 				Description: "Absolute or relative path to the base directory to traverse. Must exist and be readable.",
 			},
-			function.StringParameter{
-				Name:        "filter",
-				Description: "Glob pattern to match filenames (e.g. \"**/*.yaml\", \"config/*.json\"). Use empty string `\"\"` to include all supported files.",
-			},
+		},
+		VariadicParameter: function.StringParameter{
+			Name:        "filter",
+			Description: "Optional glob pattern to match filenames (e.g. \"**/*.yaml\", \"config/*.json\"). If omitted, includes all supported YAML and JSON files.",
 		},
 		Return: function.StringReturn{},
 	}
@@ -46,10 +46,19 @@ func (f *dirmapFunction) Definition(_ context.Context, _ function.DefinitionRequ
 // Run executes the function.
 func (f *dirmapFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
 	var path string
-	var filter string
+	var filterArgs []string
 
-	// Read arguments
-	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.Get(ctx, &path, &filter))
+	// Read required path argument
+	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.Get(ctx, &path))
+
+	// Read optional variadic filter argument
+	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.GetVariadic(ctx, &filterArgs))
+
+	// Default filter to empty string if not provided
+	filter := ""
+	if len(filterArgs) > 0 {
+		filter = filterArgs[0]
+	}
 
 	// Build the map (reuses your existing logic)
 	result, err := buildMap(path, filter)


### PR DESCRIPTION
This pull request updates the `dirmapFunction` in `provider/function_dirmap.go` to improve how the `filter` argument is handled. The main change is making the `filter` parameter optional and variadic, allowing for more flexible usage and better alignment with typical function argument patterns.

**Function signature and argument handling improvements:**

* Changed the `filter` parameter from a required string to an optional variadic parameter in the function definition, updating its description to clarify behavior when omitted.
* Updated the `Run` method to read the required `path` argument and the optional variadic `filter` arguments separately. It now defaults the `filter` to an empty string if not provided, ensuring backward compatibility and clearer argument processing.